### PR TITLE
Added support for using pipes with GO_PROMPTER_USE_PIPE

### DIFF
--- a/prompter.go
+++ b/prompter.go
@@ -64,8 +64,16 @@ func skip() bool {
 	if os.Getenv("GO_PROMPTER_USE_DEFAULT") != "" {
 		return true
 	}
+	if isPipe() {
+		return os.Getenv("GO_PROMPTER_USE_PIPE") == ""
+	}
+	return false
+}
+
+func isPipe() bool {
 	return !(isatty.IsTerminal(os.Stdin.Fd()) || isatty.IsCygwinTerminal(os.Stdin.Fd())) ||
 		!(isatty.IsTerminal(os.Stdout.Fd()) || isatty.IsCygwinTerminal(os.Stdout.Fd()))
+
 }
 
 func (p *Prompter) msg() string {


### PR DESCRIPTION
Pipe can be used and maintaining backward compatibility.
The original implementation,it was always intended to use default values when using a pipe.
refs: https://github.com/Songmu/prompter/issues/6