### PR TITLE
Make yes no prompts clearer

### DIFF
--- a/funcs.go
+++ b/funcs.go
@@ -14,9 +14,9 @@ func Prompt(message, defaultAnswer string) string {
 }
 
 // YN y/n choice
-func YN(message string, yes bool) bool {
+func YN(message string, defaultToYes bool) bool {
 	defaultChoice := "n"
-	if yes {
+	if defaultToYes {
 		defaultChoice = "y"
 	}
 	input := (&Prompter{
@@ -30,9 +30,9 @@ func YN(message string, yes bool) bool {
 }
 
 // YesNo yes/no choice
-func YesNo(message string, yes bool) bool {
+func YesNo(message string, defaultToYes bool) bool {
 	defaultChoice := "no"
-	if yes {
+	if defaultToYes {
 		defaultChoice = "yes"
 	}
 	input := (&Prompter{


### PR DESCRIPTION
When initially using this library I got confused initially because I saw the `YesNo` function's second variable, `yes bool` and thought that meant "what should the yes value evaluate to". That had the opposite effect from what I had intended.

This updates the variable to make it a bit more clear what is happening in that second variable.

I also checked that `go test` still passes 👍.